### PR TITLE
renamed link to viewpost

### DIFF
--- a/www/parts/savepost.php
+++ b/www/parts/savepost.php
@@ -35,7 +35,7 @@ $userid = $_SESSION["user"]["userid"];
         
         //header("Location: /millhouseblog/www/components/viewpost.php?postid=".$last_id);
         
-        header("Location: /millhouseblog/www/?page=post&id=".$last_id);
+        header("Location: /millhouseblog/www/?page=viewpost&id=".$last_id);
         
         
         


### PR DESCRIPTION
To reflect new name of post page to viewpost.php. When user publishes post, they're taken to the viewpost page.