### PR TITLE
added unset session newpostdata after redirect to lastpostid page so …

### DIFF
--- a/www/parts/savepost.php
+++ b/www/parts/savepost.php
@@ -47,6 +47,7 @@
 
 
             header("Location: /millhouseblog/www/?page=viewpost&id=".$last_id);
+            unset($_SESSION['new_post_data']);
 
             //print_r($statement->errorInfo());
 


### PR DESCRIPTION
…that when user creates a new post after that, all the previous data is dropped from the session variable